### PR TITLE
Template tag fixes

### DIFF
--- a/kolibri/core/templates/kolibri/base.html
+++ b/kolibri/core/templates/kolibri/base.html
@@ -1,8 +1,9 @@
 {% load i18n kolibri_tags webpack_tags %}<html>
 <head>
   <title>{% block title %}{% endblock %} - {% trans "Kolibri" %}</title>
-  {% webpack_assets 'default_frontend' %}
-  {% base_frontend_assets %}
+  {% webpack_asset 'default_frontend' %}
+  {% webpack_base_assets %}
+  {% webpack_base_async_assets %}
 </head>
 <body>
 

--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -248,12 +248,13 @@ class WebpackInclusionHook(hooks.KolibriHook):
 
     def __init__(self, *args, **kwargs):
         super(WebpackInclusionHook, self).__init__(*args, **kwargs)
-        assert \
-            self.bundle_class is not None,\
-            "Must specify bundle property, this one did not: {} ({})".format(
-                type(self),
-                type(self.bundle)
-            )
+        if not self._meta.abstract:
+            assert \
+                self.bundle_class is not None,\
+                "Must specify bundle_class property, this one did not: {} ({})".format(
+                    type(self),
+                    type(self.bundle_class)
+                )
 
     def render_to_page_load_sync_html(self, extension=None):
         html = ""

--- a/kolibri/core/webpack/templatetags/webpack_tags.py
+++ b/kolibri/core/webpack/templatetags/webpack_tags.py
@@ -21,6 +21,7 @@ from django import template
 from django.utils.safestring import mark_safe
 
 from .. import hooks
+from ..utils import webpack_asset_render
 
 register = template.Library()
 
@@ -68,12 +69,7 @@ def webpack_base_assets():
 
     :return: HTML of script tags to insert into base.html
     """
-    tags = []
-    for hook in hooks.FrontEndBaseSyncHook().registered_hooks:
-        tags.append(
-            hook.render_to_page_load_sync_html()
-        )
-    return mark_safe('\n'.join(tags))
+    return webpack_asset_render(hooks.FrontEndBaseSyncHook, async=False)
 
 
 @register.simple_tag()
@@ -85,9 +81,4 @@ def webpack_base_async_assets():
 
     :return: HTML of script tags to insert into base.html
     """
-    tags = []
-    for hook in hooks.FrontEndBaseASyncHook().registered_hooks:
-        tags.append(
-            hook.render_to_page_load_async_html()
-        )
-    return mark_safe('\n'.join(tags))
+    return webpack_asset_render(hooks.FrontEndBaseASyncHook, async=True)

--- a/kolibri/core/webpack/utils.py
+++ b/kolibri/core/webpack/utils.py
@@ -8,6 +8,8 @@ different, much of the code has simply been rewritten, and will continue to be d
 from __future__ import absolute_import, print_function, unicode_literals
 
 from django.conf import settings
+from django.utils.safestring import mark_safe
+
 
 def render_as_url(chunk):
     """
@@ -23,3 +25,18 @@ def render_as_url(chunk):
     static = getattr(settings, 'STATIC_URL')
     url = chunk.get('publicPath') or chunk['url']
     return "{static}{url}".format(static=static, url=url)
+
+def webpack_asset_render(HookClass, async=False):
+    """
+    This is produces content for a  script tag for a WebpackInclusionHook subclass that implement
+    different render to html methods either sync or async.
+    :param HookClass: a subclass of WebpackInclusionHook
+    :param sync: Render sync or async.
+    :return: HTML of script tags to insert
+    """
+    tags = []
+    for hook in HookClass().registered_hooks:
+        tags.append(
+            hook.render_to_page_load_sync_html() if not async else hook.render_to_page_load_async_html()
+        )
+    return mark_safe('\n'.join(tags))

--- a/kolibri/plugins/example_plugin/kolibri_plugin.py
+++ b/kolibri/plugins/example_plugin/kolibri_plugin.py
@@ -69,8 +69,10 @@ class ExampleAsset(webpack_hooks.WebpackBundleHook):
     unique_slug = "example_plugin"
     src_file = "kolibri/plugins/example_plugin/assets/example/example_module.js"
     static_dir = "kolibri/plugins/example_plugin/static"
+    events = {
+        "hello": "hello_world"
+    }
 
-
-class ExampleInclusionHook(webpack_hooks.FrontEndBaseSyncHook):
+class ExampleInclusionHook(webpack_hooks.FrontEndBaseASyncHook):
 
     bundle_class = ExampleAsset


### PR DESCRIPTION
Fixes up a few bugs that were stopping templates from actually rendering.

Also abstracts some of the logic in the WebpackInclusion oriented template tags to make it easier for people defining template tags for other WebpackInclusion hooks to do it without repeating themselves.

I think once this is merged, we should be good to go on the main PR, @benjaoming - I have tested it locally, and the functionality is now completely preserved!
