### PR TITLE
Ignore undefined linting of Py2 only globals in Py2 only code blocks.

### DIFF
--- a/kolibri/core/analytics/pskolibri/__init__.py
+++ b/kolibri/core/analytics/pskolibri/__init__.py
@@ -228,7 +228,7 @@ class Process(object):
         if pid is None:
             pid = os.getpid()
         else:
-            if not PY3 and not isinstance(pid, (int, long)):
+            if not PY3 and not isinstance(pid, (int, long)):  # noqa F821
                 raise TypeError('pid must be an integer (got %r)' % pid)
             if pid < 0:
                 raise ValueError('pid must be a positive integer (got %s)' % pid)

--- a/kolibri/core/decorators.py
+++ b/kolibri/core/decorators.py
@@ -36,7 +36,7 @@ TUPLE_TYPES = tuple, set, frozenset, list
 if (sys.version_info > (3, 0)):
     VALID_TYPES = int, float, str, bool
 else:
-    VALID_TYPES = int, float, str, unicode, bool
+    VALID_TYPES = int, float, str, unicode, bool  # noqa F821
 
 
 class ParamValidator(object):


### PR DESCRIPTION
Fix erroneous Py3 linting errors.